### PR TITLE
Add JSCS configuration and run checks on Travis CI

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,23 @@
+{
+	"preset": "wikimedia",
+
+	"disallowDanglingUnderscores": null,
+
+	"jsDoc": {
+		"checkAnnotations": {
+			"preset": "jsduck5",
+			"extra": {
+				"licence": true
+			}
+		},
+		"checkParamNames": true,
+		"requireParamTypes": true,
+		"checkRedundantParams": true,
+		"checkReturnTypes": true,
+		"checkRedundantReturns": true,
+		"requireReturnTypes": true,
+		"checkTypes": "strictNativeCase",
+		"checkRedundantAccess": true,
+		"requireNewlineAfterDescription": true
+	}
+}

--- a/.jscsrc
+++ b/.jscsrc
@@ -19,5 +19,14 @@
 		"checkTypes": "strictNativeCase",
 		"checkRedundantAccess": true,
 		"requireNewlineAfterDescription": true
-	}
+	},
+
+	"excludeFiles": [
+		"node_modules/**",
+		"js/lib/**",
+		"js/sensitive_banner_all.js",
+		"sensitive-banner-static/**",
+		"tests/lib/**",
+		"vendor/**"
+	]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ node_js:
 
 sudo: false
 
-install: travis_retry npm install qunit-phantomjs-runner jshint
+install: travis_retry npm install qunit-phantomjs-runner jshint jscs
 
 script:
   - phantomjs node_modules/qunit-phantomjs-runner/runner.js tests/ci-tests.html
   - ./node_modules/jshint/bin/jshint .
+  - ./node_modules/jscs/bin/jscs .

--- a/js/banner/banner.api.js
+++ b/js/banner/banner.api.js
@@ -1,7 +1,7 @@
 /**
  * Donation API used in the banner
  *
- * @license GNU GPL v2+
+ * @licence GNU GPL v2+
  * @author Leszek Manicki <leszek.manicki@wikimedia.de>
  */
 ( function ( banner, $ ) {

--- a/js/banner/banner.api.js
+++ b/js/banner/banner.api.js
@@ -87,6 +87,7 @@
 
 	/**
 	 * Sends a reqeust to the API to generate IBAN and BIC from bank data
+	 *
 	 * @param {Object} data
 	 * @return {Promise}
 	 *         Resolved parameter:
@@ -109,6 +110,7 @@
 
 	/**
 	 * Sends a reqeust to the API to check the validate of an IBAN
+	 *
 	 * @param {Object} data
 	 * @return {Promise}
 	 *         Resolved parameter:

--- a/js/banner/banner.api.js
+++ b/js/banner/banner.api.js
@@ -28,12 +28,12 @@
 	 * @param {Object} data
 	 * @return {Promise}
 	 */
-	Api.prototype.sendEncryptedRequest = function ( module, action, data ) {
+	Api.prototype._sendEncryptedRequest = function ( module, action, data ) {
 		var self = this;
 		return banner.encryption.encrypt( $.param( data ) )
 			.then( function ( encryptedData ) {
-				return self.sendRequest( module, action, {
-					enc: self.encodeBase64( encryptedData )
+				return self._sendRequest( module, action, {
+					enc: self._encodeBase64( encryptedData )
 				} );
 			} );
 	};
@@ -44,7 +44,7 @@
 	 * @param {Object} data
 	 * @return {string}
 	 */
-	Api.prototype.encodeBase64 = function ( data ) {
+	Api.prototype._encodeBase64 = function ( data ) {
 		return window.btoa( data );
 	};
 
@@ -56,7 +56,7 @@
 	 * @param {Object} data
 	 * @return {Object} jQuery XMLHttpRequest (jqXHR)
 	 */
-	Api.prototype.sendRequest = function ( module, action, data ) {
+	Api.prototype._sendRequest = function ( module, action, data ) {
 		var requestData = data;
 		$.extend( requestData, { module: module, action: action } );
 		return $.ajax( {
@@ -78,7 +78,7 @@
 	 *                  - missing: array containing names of missing obligatory fields.
 	 */
 	Api.prototype.sendValidationRequest = function ( data ) {
-		return this.sendEncryptedRequest(
+		return this._sendEncryptedRequest(
 			banner.config.api.validationModule,
 			banner.config.api.validationAction,
 			data

--- a/js/banner/banner.api.js
+++ b/js/banner/banner.api.js
@@ -4,7 +4,7 @@
  * @license GNU GPL v2+
  * @author Leszek Manicki <leszek.manicki@wikimedia.de>
  */
-( function( banner, $ ) {
+( function ( banner, $ ) {
 	'use strict';
 
 	function Api() {
@@ -28,10 +28,10 @@
 	 * @param {Object} data
 	 * @return {Promise}
 	 */
-	Api.prototype.sendEncryptedRequest = function( module, action, data ) {
+	Api.prototype.sendEncryptedRequest = function ( module, action, data ) {
 		var self = this;
 		return banner.encryption.encrypt( $.param( data ) )
-			.then( function( encryptedData ) {
+			.then( function ( encryptedData ) {
 				return self.sendRequest( module, action, {
 					enc: self.encodeBase64( encryptedData )
 				} );
@@ -44,7 +44,7 @@
 	 * @param {Object} data
 	 * @return {string}
 	 */
-	Api.prototype.encodeBase64 = function( data ) {
+	Api.prototype.encodeBase64 = function ( data ) {
 		return window.btoa( data );
 	};
 
@@ -56,7 +56,7 @@
 	 * @param {Object} data
 	 * @return {Object} jQuery XMLHttpRequest (jqXHR)
 	 */
-	Api.prototype.sendRequest = function( module, action, data ) {
+	Api.prototype.sendRequest = function ( module, action, data ) {
 		var requestData = data;
 		$.extend( requestData, { module: module, action: action } );
 		return $.ajax( {
@@ -77,7 +77,7 @@
 	 *                  - invalid: array containing names of fields with invalid values,
 	 *                  - missing: array containing names of missing obligatory fields.
 	 */
-	Api.prototype.sendValidationRequest = function( data ) {
+	Api.prototype.sendValidationRequest = function ( data ) {
 		return this.sendEncryptedRequest(
 			banner.config.api.validationModule,
 			banner.config.api.validationAction,

--- a/js/banner/banner.config.js
+++ b/js/banner/banner.config.js
@@ -4,7 +4,7 @@
  * @licence GNU GPL v2+
  * @author Kai Nissen <kai.nissen@wikimedia.de>
  */
-( function( Banner ) {
+( function ( Banner ) {
 	'use strict';
 
 	Banner.config = {
@@ -52,7 +52,7 @@
 				}
 			}
 		},
-		setConfig: function( settings ) {
+		setConfig: function ( settings ) {
 			$.extend( true, Banner.config, settings );
 		}
 	};

--- a/js/banner/banner.encryption.js
+++ b/js/banner/banner.encryption.js
@@ -39,7 +39,7 @@
 	/**
 	 * Encrypts a message and puts the encrypted data into the given field
 	 *
-	 * @param data The message to encrypt
+	 * @param {string} data The message to encrypt
 	 * @return {Promise}
 	 */
 	EP.encrypt = function ( data ) {

--- a/js/banner/banner.encryption.js
+++ b/js/banner/banner.encryption.js
@@ -43,8 +43,9 @@
 	 * @return {Promise}
 	 */
 	EP.encrypt = function ( data ) {
+		var publicKey;
 		if ( this.initialized ) {
-			var publicKey = openpgp.key.readArmored( Banner.config.encryption.publicKey );
+			publicKey = openpgp.key.readArmored( Banner.config.encryption.publicKey );
 
 			return openpgp.encryptMessage( publicKey.keys, data )
 				.then( function ( pgpMessage ) {

--- a/js/banner/banner.encryption.js
+++ b/js/banner/banner.encryption.js
@@ -4,7 +4,7 @@
  * @licence GNU GPL v2+
  * @author Kai Nissen <kai.nissen@wikimedia.de>
  */
-( function( Banner ) {
+( function ( Banner ) {
 	'use strict';
 
 	var EP;
@@ -13,7 +13,7 @@
 		var self = this;
 		this.initialized = false;
 
-		$( document ).ready( function() {
+		$( document ).ready( function () {
 			self.initCryptLib();
 		} );
 	}
@@ -30,7 +30,7 @@
 			url: Banner.config.encryption.libUrl,
 			dataType: 'script',
 			cache: true,
-			success: function() {
+			success: function () {
 				self.initialized = true;
 			}
 		} );
@@ -38,6 +38,7 @@
 
 	/**
 	 * Encrypts a message and puts the encrypted data into the given field
+	 *
 	 * @param data The message to encrypt
 	 * @return {Promise}
 	 */
@@ -46,7 +47,7 @@
 			var publicKey = openpgp.key.readArmored( Banner.config.encryption.publicKey );
 
 			return openpgp.encryptMessage( publicKey.keys, data )
-				.then( function( pgpMessage ) {
+				.then( function ( pgpMessage ) {
 					return pgpMessage;
 				} );
 		}

--- a/js/banner/banner.form.js
+++ b/js/banner/banner.form.js
@@ -4,7 +4,7 @@
  * @license GNU GPL v2+
  * @author Leszek Manicki <leszek.manicki@wikimedia.de>
  */
-( function( banner, $ ) {
+( function ( banner, $ ) {
 	'use strict';
 
 	function Form() {
@@ -12,30 +12,30 @@
 		this.validated = false;
 		this.validationPending = false;
 		this.bankCheckPending = false;
-		$( document ).ready( function() {
+		$( document ).ready( function () {
 			self.amountValidationAnchor = $( '#amount75' );
 			self._initSubmitHandler();
 			self._initBankDataHandler();
 			self._initFieldClearHandlers();
-			$( '#' + banner.config.form.formId + ' .amount-radio' ).on( 'click', function() {
+			$( '#' + banner.config.form.formId + ' .amount-radio' ).on( 'click', function () {
 				self._clearElementValidity( self.amountValidationAnchor );
 			} );
 		} );
 	}
 
-	Form.prototype._initSubmitHandler = function() {
+	Form.prototype._initSubmitHandler = function () {
 		var self = this;
 		var form = $( '#' + banner.config.form.formId );
 		form.prop( 'action', banner.config.form.formAction );
-		form.on( 'submit', function() {
-			if( !self.validated && !self.validationPending ) {
+		form.on( 'submit', function () {
+			if ( !self.validated && !self.validationPending ) {
 				self.validated = false;
 				self.validationPending = true;
 				self._clearValidity();
 				self.validateData( self._getFormData() )
-					.then( function( validationResult ) {
+					.then( function ( validationResult ) {
 						self.validationPending = false;
-						if( validationResult.validated ) {
+						if ( validationResult.validated ) {
 							self.validated = true;
 							form.trigger( 'banner:validationSucceeded' );
 						} else {
@@ -48,34 +48,34 @@
 		} );
 	};
 
-	Form.prototype._initFieldClearHandlers = function() {
-		var clearBankData = function() {
-			$( '#' + banner.config.form.formId + ' input[name=bic]').val( '' );
-			$( '#' + banner.config.form.formId + ' input[name=iban]').val( '' );
-			$( '#' + banner.config.form.formId + ' input[name=konto]').val( '' );
-			$( '#' + banner.config.form.formId + ' input[name=blz]').val( '' );
-			$( '#' + banner.config.form.formId + ' input[name=bankname]').val( '' );
+	Form.prototype._initFieldClearHandlers = function () {
+		var clearBankData = function () {
+			$( '#' + banner.config.form.formId + ' input[name=bic]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=iban]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=konto]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=blz]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=bankname]' ).val( '' );
 		};
-		$( '#address-type-1' ).on( 'click', function() {
-			$( '#' + banner.config.form.formId + ' input[name=firma]').val('');
+		$( '#address-type-1' ).on( 'click', function () {
+			$( '#' + banner.config.form.formId + ' input[name=firma]' ).val( '' );
 		} );
-		$( '#address-type-2' ).on( 'click', function() {
-			$( '#' + banner.config.form.formId + ' input[name=vorname]').val( '' );
-			$( '#' + banner.config.form.formId + ' input[name=nachname]').val( '' );
-			$( '#' + banner.config.form.formId + ' select[name=titel]').val( '' );
+		$( '#address-type-2' ).on( 'click', function () {
+			$( '#' + banner.config.form.formId + ' input[name=vorname]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=nachname]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' select[name=titel]' ).val( '' );
 		} );
-		$( '#address-type-3' ).on( 'click', function() {
-			$( '#' + banner.config.form.formId + ' input[name=firma]').val('');
-			$( '#' + banner.config.form.formId + ' input[name=vorname]').val( '' );
-			$( '#' + banner.config.form.formId + ' input[name=nachname]').val( '' );
-			$( '#' + banner.config.form.formId + ' input[name=anrede]').prop( 'checked', false );
-			$( '#' + banner.config.form.formId + ' select[name=titel]').val( '' );
-			$( '#' + banner.config.form.formId + ' input[name=email]').val( '' );
-			$( '#' + banner.config.form.formId + ' input[name=plz]').val( '' );
-			$( '#' + banner.config.form.formId + ' input[name=ort]').val( '' );
-			$( '#' + banner.config.form.formId + ' input[name=strasse]').val( '' );
+		$( '#address-type-3' ).on( 'click', function () {
+			$( '#' + banner.config.form.formId + ' input[name=firma]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=vorname]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=nachname]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=anrede]' ).prop( 'checked', false );
+			$( '#' + banner.config.form.formId + ' select[name=titel]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=email]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=plz]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=ort]' ).val( '' );
+			$( '#' + banner.config.form.formId + ' input[name=strasse]' ).val( '' );
 		} );
-		$( '#WMDE_BannerForm-payment button' ).each( function( index, element ) {
+		$( '#WMDE_BannerForm-payment button' ).each( function ( index, element ) {
 			var $element = $( element );
 
 			if ( $element.data( 'behavior' ) === 'clearBankData' ) {
@@ -84,28 +84,29 @@
 		} );
 	};
 
-	Form.prototype._initBankDataHandler = function() {
+	Form.prototype._initBankDataHandler = function () {
 		$( '#account-number, #bank-code, #iban' ).on( 'change', this.checkBankData.bind( this ) );
 	};
 
 	Form.prototype.checkBankData = function ( evt ) {
 		var cleanBankData = function ( data, isIBAN ) {
-			data = data.toString();
-			if ( isIBAN ) {
-				data = data.toUpperCase();
-				return data.replace( /[^0-9A-Z]/g, '' );
-			} else {
-				return data.replace( /[^0-9]/g, '' );
-			}
-		},
-		self = this,
-		data, apiMethod;
+				data = data.toString();
+				if ( isIBAN ) {
+					data = data.toUpperCase();
+					return data.replace( /[^0-9A-Z]/g, '' );
+				} else {
+					return data.replace( /[^0-9]/g, '' );
+				}
+			},
+			self = this,
+			data,
+			apiMethod;
 
 		if ( evt.target.id === 'account-number' || evt.target.id === 'bank-code' ) {
 			var accNumElm = $( '#account-number' );
 			var bankCodeElm = $( '#bank-code' );
 
-			if( accNumElm.val() === '' || bankCodeElm.val() === '' ) {
+			if ( accNumElm.val() === '' || bankCodeElm.val() === '' ) {
 				return;
 			}
 			data = {
@@ -114,10 +115,10 @@
 			};
 			apiMethod = banner.api.sendIbanGenerationRequest.bind( banner.api );
 		} else if ( evt.target.id === 'iban' ) {
-			data = { iban: cleanBankData(evt.target.value, true) };
+			data = { iban: cleanBankData( evt.target.value, true ) };
 			apiMethod = banner.api.sendIbanCheckRequest.bind( banner.api );
 		}
-		$( '#bic, #iban, #account-number, #bank-code').each( function ( index, element ) {
+		$( '#bic, #iban, #account-number, #bank-code' ).each( function ( index, element ) {
 			self._clearElementValidity( $( element ) );
 		} );
 		this.bankCheckPending = true;
@@ -132,7 +133,7 @@
 			$( '#bic' ).val( data.bic ? data.bic : '' );
 			$( '#account-number' ).val( data.account ? data.account : '' );
 			$( '#bank-code' ).val( data.bankCode ? data.bankCode : '' );
-			$( '#bank-name' ).val( data.bankName ? data.bankName: '' );
+			$( '#bank-name' ).val( data.bankName ? data.bankName : '' );
 		} else {
 			$iban.val( '' );
 			errorMessage = data.message || 'Die eingegebenen Bankdaten sind nicht korrekt.';
@@ -142,15 +143,15 @@
 		this.bankCheckPending = false;
 	};
 
-	Form.prototype._clearValidity = function() {
+	Form.prototype._clearValidity = function () {
 		var self = this;
-		$( '#' + banner.config.form.formId + ' :input:not([type=hidden])' ).each( function( index, element ) {
+		$( '#' + banner.config.form.formId + ' :input:not([type=hidden])' ).each( function ( index, element ) {
 			self._clearElementValidity( $( element ) );
 		} );
 		self._clearElementValidity( this.amountValidationAnchor );
 	};
 
-	Form.prototype._clearElementValidity = function( $element ) {
+	Form.prototype._clearElementValidity = function ( $element ) {
 		var $parent = $element.parent();
 		$element.removeClass( 'invalid' ).removeClass( 'valid' );
 		$( '.validation', $parent ).removeClass( 'icon-bug' ).removeClass( 'icon-ok' );
@@ -160,7 +161,7 @@
 	/**
 	 * @return {Object}
 	 */
-	Form.prototype._getFormData = function() {
+	Form.prototype._getFormData = function () {
 		/* globals getAmount */
 		var formId = banner.config.form.formId,
 			formData = {
@@ -168,7 +169,7 @@
 				betrag: getAmount(),
 				periode: $( '#' + formId + ' :input[name="periode"]' ).val(),
 				zahlweise:  $( '#zahlweise' ).val()
-		};
+			};
 		if ( formData.adresstyp !== 'anonym' ) {
 			$.extend( formData, {
 				country: $( '#' + formId + ' select[name="country"]' ).val(),
@@ -185,8 +186,7 @@
 				vorname: $( '#' + formId + ' :input[name="vorname"]' ).val(),
 				nachname: $( '#' + formId + ' :input[name="nachname"]' ).val()
 			} );
-		}
-		else if ( formData.adresstyp === 'firma' ) {
+		} else if ( formData.adresstyp === 'firma' ) {
 			$.extend( formData, {
 				firma: $( '#' + formId + ' :input[name="firma"]' ).val(),
 				anrede: 'Firma'
@@ -215,10 +215,10 @@
 	 *                  - fieldsMissingValue: array containing names of fields with invalid values,
 	 *                  - fieldsWithInvalidValue: array containing names of missing obligatory fields.
 	 */
-	Form.prototype.validateData = function( data ) {
+	Form.prototype.validateData = function ( data ) {
 		return banner.api.sendValidationRequest( data )
-			.then( function( responseData ) {
-				if( responseData.status === 'OK' ) {
+			.then( function ( responseData ) {
+				if ( responseData.status === 'OK' ) {
 					return {
 						validated: true
 					};
@@ -236,7 +236,7 @@
 	 * @param {string[]} fieldsMissingValue
 	 * @param {string[]} fieldsWithInvalidValue
 	 */
-	Form.prototype._applyValidationErrors = function( fieldsMissingValue, fieldsWithInvalidValue ) {
+	Form.prototype._applyValidationErrors = function ( fieldsMissingValue, fieldsWithInvalidValue ) {
 		var self = this,
 			valueMissingIndex = $.inArray( 'betrag', fieldsMissingValue ),
 			valueInvalidIndex = $.inArray( 'betrag', fieldsWithInvalidValue );
@@ -253,12 +253,12 @@
 			fieldsMissingValue.splice( valueMissingIndex, 1 );
 		}
 
-		$( '#' + banner.config.form.formId + ' :input:not([type=hidden])' ).each( function( index, element ) {
-			if( $.inArray( $( element ).attr( 'name' ), fieldsMissingValue ) > -1 ) {
+		$( '#' + banner.config.form.formId + ' :input:not([type=hidden])' ).each( function ( index, element ) {
+			if ( $.inArray( $( element ).attr( 'name' ), fieldsMissingValue ) > -1 ) {
 				self._markMissing( $( element ) );
 				return true;
 			}
-			if( $.inArray( $( element ).attr( 'name' ), fieldsWithInvalidValue ) > -1 ) {
+			if ( $.inArray( $( element ).attr( 'name' ), fieldsWithInvalidValue ) > -1 ) {
 				self._markInvalid( $( element ) );
 				return true;
 			}
@@ -266,23 +266,22 @@
 		} );
 	};
 
-	Form.prototype._markInvalid = function( $element ) {
+	Form.prototype._markInvalid = function ( $element ) {
 		this._showError( $element );
 	};
 
-	Form.prototype._markMissing = function( $element ) {
+	Form.prototype._markMissing = function ( $element ) {
 		// Since the server-side validation does not get missing fields except for amount,
 		// we use a more generic error message and handle the errors the same
 		this._showError( $element );
 	};
 
-	Form.prototype._showError = function( $element ) {
+	Form.prototype._showError = function ( $element ) {
 		var $parent = $element.parent(),
 			errorText;
 		if ( arguments.length > 1 ) {
-			errorText = arguments[1];
-		}
-		else {
+			errorText = arguments[ 1 ];
+		} else {
 			errorText = 'Bitte korrigieren Sie dieses Feld.';
 		}
 		$element.addClass( 'invalid' );
@@ -296,7 +295,7 @@
 		}
 	};
 
-	Form.prototype._markValid = function( $element ) {
+	Form.prototype._markValid = function ( $element ) {
 		var $parent = $element.parent();
 		$element.addClass( 'valid' );
 		$( '.validation', $parent ).addClass( 'icon-ok' );

--- a/js/banner/banner.form.js
+++ b/js/banner/banner.form.js
@@ -24,8 +24,8 @@
 	}
 
 	Form.prototype._initSubmitHandler = function () {
-		var self = this;
-		var form = $( '#' + banner.config.form.formId );
+		var self = this,
+			form = $( '#' + banner.config.form.formId );
 		form.prop( 'action', banner.config.form.formAction );
 		form.on( 'submit', function () {
 			if ( !self.validated && !self.validationPending ) {
@@ -100,11 +100,11 @@
 			},
 			self = this,
 			data,
-			apiMethod;
+			apiMethod,
+			accNumElm = $( '#account-number' ),
+			bankCodeElm = $( '#bank-code' );
 
 		if ( evt.target.id === 'account-number' || evt.target.id === 'bank-code' ) {
-			var accNumElm = $( '#account-number' );
-			var bankCodeElm = $( '#bank-code' );
 
 			if ( accNumElm.val() === '' || bankCodeElm.val() === '' ) {
 				return;

--- a/js/banner/banner.form.js
+++ b/js/banner/banner.form.js
@@ -1,7 +1,7 @@
 /**
  * Class handling submitting of the donation form embedded in the banner.
  *
- * @license GNU GPL v2+
+ * @licence GNU GPL v2+
  * @author Leszek Manicki <leszek.manicki@wikimedia.de>
  */
 ( function ( banner, $ ) {

--- a/js/banner/banner.js
+++ b/js/banner/banner.js
@@ -1,12 +1,12 @@
 /**
  * JavaScript library for general banner functionalities
- * 
+ *
  * @licence GNU GPL v2+
  * @author Kai Nissen <kai.nissen@wikimedia.de>
  */
 var Banner;
 
-( function() {
+( function () {
 	'use strict';
 
 	Banner = {};

--- a/js/banner/banner.tracking.js
+++ b/js/banner/banner.tracking.js
@@ -24,7 +24,7 @@
 	/**
 	 * Set the tracker lib
 	 *
-	 * @param Tracker an instance of Piwik's Tracker class
+	 * @param {Tracker} tracker an instance of Piwik's Tracker class
 	 */
 	TP.setTracker = function ( tracker ) {
 		this._tracker = tracker;
@@ -33,7 +33,7 @@
 	/**
 	 * Track a virtual page view
 	 *
-	 * @param eventName
+	 * @param {string} eventName
 	 */
 	TP.trackVirtualPageView = function ( eventName ) {
 		if ( this.shouldTrack( eventName, this.getRandomNumber() ) ) {
@@ -49,8 +49,8 @@
 	/**
 	 * Determines whether an event should be tracked
 	 *
-	 * @param eventName event name based on the property keys of Banner.tracking.events
-	 * @param randomNumber randomly generated number to compare against the configured sample size
+	 * @param {string} eventName event name based on the property keys of Banner.tracking.events
+	 * @param {number} randomNumber randomly generated number to compare against the configured sample size
 	 * @return {boolean}
 	 */
 	TP.shouldTrack = function ( eventName, randomNumber ) {

--- a/js/banner/banner.tracking.js
+++ b/js/banner/banner.tracking.js
@@ -60,7 +60,7 @@
 	};
 
 	/**
-	 * @returns {number}
+	 * @return {number}
 	 */
 	TP.getRandomNumber = function () {
 		return Math.random() * ( 1 - 0.01 ) + 0.01;

--- a/js/banner/banner.tracking.js
+++ b/js/banner/banner.tracking.js
@@ -4,16 +4,16 @@
  * @licence GNU GPL v2+
  * @author Kai Nissen <kai.nissen@wikimedia.de>
  */
-( function( Banner ) {
+( function ( Banner ) {
 	'use strict';
-	
+
 	var TP;
 
 	function Tracking() {
 		var self = this;
 		this._tracker = null;
 
-		$( document ).ready( function() {
+		$( document ).ready( function () {
 			self.initTrackingLib();
 			self.initClickHandlers();
 		} );
@@ -24,7 +24,7 @@
 	/**
 	 * Set the tracker lib
 	 *
-	 * @param Tracker an instance of Piwik's Tracker class   
+	 * @param Tracker an instance of Piwik's Tracker class
 	 */
 	TP.setTracker = function ( tracker ) {
 		this._tracker = tracker;
@@ -39,7 +39,7 @@
 		if ( this.shouldTrack( eventName, this.getRandomNumber() ) ) {
 			this._tracker.trackPageView(
 				Banner.config.tracking.baseUrl +
-				Banner.config.tracking.events[eventName].pathName +
+				Banner.config.tracking.events[ eventName ].pathName +
 				'/' +
 				Banner.config.tracking.keyword
 			);
@@ -49,14 +49,14 @@
 	/**
 	 * Determines whether an event should be tracked
 	 *
-	 * @param eventName event name based on the property keys of Banner.tracking.events 
+	 * @param eventName event name based on the property keys of Banner.tracking.events
 	 * @param randomNumber randomly generated number to compare against the configured sample size
 	 * @return {boolean}
 	 */
 	TP.shouldTrack = function ( eventName, randomNumber ) {
 		return this._tracker &&
-			Banner.config.tracking.events[eventName] &&
-			Banner.config.tracking.events[eventName].sample > randomNumber;
+			Banner.config.tracking.events[ eventName ] &&
+			Banner.config.tracking.events[ eventName ].sample > randomNumber;
 	};
 
 	/**
@@ -69,13 +69,13 @@
 	/**
 	 * fetch the piwik library and get the specified tracker from it
 	 */
-	TP.initTrackingLib = function() {
+	TP.initTrackingLib = function () {
 		var self = this;
 		$.ajax( {
 			url: Banner.config.tracking.libUrl,
 			dataType: 'script',
 			cache: true,
-			success: function() {
+			success: function () {
 				var trackingConfig = Banner.config.tracking;
 				self.setTracker( Piwik.getTracker( trackingConfig.trackerUrl, trackingConfig.siteId ) );
 			}
@@ -85,7 +85,7 @@
 	/**
 	 * bind click events to elements as configured
 	 */
-	TP.initClickHandlers = function() {
+	TP.initClickHandlers = function () {
 		$.each( Banner.config.tracking.events, function ( key, settings ) {
 			$( settings.clickElement ).click( function () {
 				Banner.tracking.trackVirtualPageView( key );

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -1,10 +1,10 @@
 $( document ).ready( function () {
-	$( '.list-item-title' ).on( 'click', function() {
+	$( '.list-item-title' ).on( 'click', function () {
 		$( this ).toggleClass( 'opened' );
 		$( this ).next().toggle();
 	} );
 
-	$( '.banner-lightbox-close' ).on( 'click', function() {
+	$( '.banner-lightbox-close' ).on( 'click', function () {
 		$( this ).parent().slideToggle();
 	} );
-});
+} );

--- a/lightbox-security.html
+++ b/lightbox-security.html
@@ -6,12 +6,12 @@
   <script type="text/javascript" src="js/lib/jquery-1.11.3.min.js"></script>
   <script type="text/javascript" src="js/lightbox.js"></script>
   <script>
-    $( document ).ready( function() {
-      $( '.list-item-title' ).on( 'click', function() {
-        $( this ).toggleClass( 'opened' );
-        $( this ).next().toggle();
-      } );
-    } );
+	$( document ).ready( function () {
+		$( '.list-item-title' ).on( 'click', function () {
+			$( this ).toggleClass( 'opened' );
+			$( this ).next().toggle();
+		} );
+	} );
   </script>
 </head>
 

--- a/tests/banner.api.tests.js
+++ b/tests/banner.api.tests.js
@@ -1,5 +1,5 @@
 /**
-* @license GNU GPL v2+
+* @licence GNU GPL v2+
 * @author Leszek Manicki <leszek.manicki@wikimedia.de>
 */
 ( function ( banner, QUnit ) {

--- a/tests/banner.api.tests.js
+++ b/tests/banner.api.tests.js
@@ -2,11 +2,11 @@
 * @license GNU GPL v2+
 * @author Leszek Manicki <leszek.manicki@wikimedia.de>
 */
-( function( banner, QUnit ) {
+( function ( banner, QUnit ) {
 
 	QUnit.module( 'Banner.api tests' );
 
-	QUnit.test( 'When given valid data Api.validateData returns status OK', function( assert ) {
+	QUnit.test( 'When given valid data Api.validateData returns status OK', function ( assert ) {
 		var data = {
 			betrag: '5.00',
 			periode: '0',
@@ -25,13 +25,13 @@
 		done = assert.async();
 
 		banner.api.sendValidationRequest( data )
-			.then( function( responseData ) {
+			.then( function ( responseData ) {
 				assert.equal( responseData.status, 'OK' );
 				done();
 			} );
 	} );
 
-	QUnit.test( 'When given data missing obligatory fields Api.validateData returns status error and list of missing fields', function( assert ) {
+	QUnit.test( 'When given data missing obligatory fields Api.validateData returns status error and list of missing fields', function ( assert ) {
 		var data = {
 			periode: '0',
 			zahlweise: 'UEB',
@@ -48,14 +48,14 @@
 		done = assert.async();
 
 		banner.api.sendValidationRequest( data )
-			.then( function( responseData ) {
+			.then( function ( responseData ) {
 				assert.equal( responseData.status, 'ERR' );
 				assert.deepEqual( responseData.missing, [ 'betrag', 'nachname' ] );
 				done();
 			} );
 	} );
 
-	QUnit.test( 'When given data containing invalid values Api.validateData returns status error and list of fields with invalid values', function( assert ) {
+	QUnit.test( 'When given data containing invalid values Api.validateData returns status error and list of fields with invalid values', function ( assert ) {
 		var data = {
 				betrag: '5.00',
 				periode: '0',
@@ -74,7 +74,7 @@
 			done = assert.async();
 
 		banner.api.sendValidationRequest( data )
-			.then( function( responseData ) {
+			.then( function ( responseData ) {
 				assert.equal( responseData.status, 'ERR' );
 				assert.deepEqual( responseData.invalid, [ 'email', 'plz' ] );
 				done();

--- a/tests/banner.form.tests.js
+++ b/tests/banner.form.tests.js
@@ -2,10 +2,10 @@
  * @license GNU GPL v2+
  * @author Leszek Manicki <leszek.manicki@wikimedia.de>
  */
-( function( banner, QUnit ) {
+( function ( banner, QUnit ) {
 	QUnit.module( 'Banner\'s donation form' );
 
-	QUnit.test( 'Given valid data Form.validateData returns true', function( assert ) {
+	QUnit.test( 'Given valid data Form.validateData returns true', function ( assert ) {
 		var data = {
 				betrag: '5.00',
 				periode: '0',
@@ -24,7 +24,7 @@
 			done = assert.async();
 
 		banner.form.validateData( data )
-			.then( function( validationResult ) {
+			.then( function ( validationResult ) {
 				assert.ok( validationResult.validated );
 				done();
 			} );

--- a/tests/banner.form.tests.js
+++ b/tests/banner.form.tests.js
@@ -1,5 +1,5 @@
 /**
- * @license GNU GPL v2+
+ * @licence GNU GPL v2+
  * @author Leszek Manicki <leszek.manicki@wikimedia.de>
  */
 ( function ( banner, QUnit ) {

--- a/tests/banner.tests.js
+++ b/tests/banner.tests.js
@@ -4,7 +4,7 @@
  * @licence GNU GPL v2+
  * @author Kai Nissen <kai.nissen@wikimedia.de>
  */
-( function( Banner, QUnit ) {
+( function ( Banner, QUnit ) {
 
 	QUnit.module( 'Banner.tracking' );
 
@@ -58,7 +58,7 @@
 		}
 	} );
 
-	QUnit.test( 'setConfig() overrides configuration properly', function( assert ) {
+	QUnit.test( 'setConfig() overrides configuration properly', function ( assert ) {
 		assert.equal(
 			Banner.config.tracking.events.BANNER_CLOSED.sample,
 			0.8,
@@ -72,23 +72,23 @@
 		);
 	} );
 
-	QUnit.test( 'Banner.tracking.shouldTrack() returns correct values', function( assert ) {
+	QUnit.test( 'Banner.tracking.shouldTrack() returns correct values', function ( assert ) {
 		assert.equal( Banner.tracking.shouldTrack( 'BANNER_CLOSED', 0.05 ), true );
 		assert.equal( Banner.tracking.shouldTrack( 'BANNER_CLOSED', 0.85 ), false );
 		assert.equal( Banner.tracking.shouldTrack( 'BANNER_EXPANDED', 0.05 ), false );
 	} );
 
-	QUnit.test( 'Click handlers are set', function( assert ) {
+	QUnit.test( 'Click handlers are set', function ( assert ) {
 		assert.ok( $._data( $( '#qunit-fixture' ).get( 0 ), 'events' ) );
 		assert.notOk( $._data( $( '#qunit' ).get( 0 ), 'events' ) );
 	} );
 
 	QUnit.module( 'Banner.encryption' );
 
-	QUnit.test( 'Message can be encrypted', function( assert ) {
+	QUnit.test( 'Message can be encrypted', function ( assert ) {
 		var done = assert.async();
 
-		Banner.encryption.encrypt( 'Hello, Dexter Morgan!' ).then( function( pgpMessage ) {
+		Banner.encryption.encrypt( 'Hello, Dexter Morgan!' ).then( function ( pgpMessage ) {
 			assert.ok( pgpMessage.indexOf( 'BEGIN PGP MESSAGE' ) !== -1 );
 			done();
 		} );


### PR DESCRIPTION
JSCS-related part of https://github.com/wmde/FundraisingBanners/pull/4 reloaded.

After discussion in that pull request, I suggest to comply with Mediawiki style (https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript) and use wikimedia JSCS preset (see: https://github.com/jscs-dev/node-jscs/blob/master/presets/wikimedia.json).
Only differences are that we distinguish private-like functions by prefixing them with underscores, and use non-standard "@licence" doc tag (unfortunately whole `jsDoc` block in config file must be copied from the preset in order to have all settings from there and add single custom tag).