### PR TITLE
Fix JSHint check on Travis CI

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,3 +1,4 @@
 node_modules
 js/lib
+sensitive-banner-static
 tests/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install: travis_retry npm install qunit-phantomjs-runner jshint
 
 script:
   - phantomjs node_modules/qunit-phantomjs-runner/runner.js tests/ci-tests.html
-  - ./node_modules/jshint/bin/jshint
+  - ./node_modules/jshint/bin/jshint .


### PR DESCRIPTION
This is embarrassing to admit but the command running JSHint checks added in https://github.com/wmde/FundraisingBanners/pull/7 does not actually run any checks.
This is fixing this. Also ignoring (temporarily) sensitive banner stuff to have builds pass on Travis.