### PR TITLE
fix text alignment for wp.de

### DIFF
--- a/sensitive-banner-static/res/common-banner.css
+++ b/sensitive-banner-static/res/common-banner.css
@@ -40,6 +40,7 @@
     background: transparent;
     display: none;
     font-family: Arial, Helvetica, Verdana, sans-serif;
+    text-align: left;
     left: 0;
     position: fixed;
     top: 0;


### PR DESCRIPTION
On wp.de banners are inside a `<center>` tag. Reassure text is generally left aligned.