### PR TITLE
Add tracking of closing the sensitive banner and expanding the in-banner form

### DIFF
--- a/combine_assets.php
+++ b/combine_assets.php
@@ -6,6 +6,7 @@ $allAssets = [
         'sensitive-banner-static/res/lightbox.js',
         'js/banner/banner.js',
         'js/banner/banner.config.js',
+        'js/banner/banner.tracking.js',
         'js/banner/banner.encryption.js',
         'js/banner/banner.api.js',
         'js/banner/banner.form.js',

--- a/js/banner/banner.tracking.js
+++ b/js/banner/banner.tracking.js
@@ -4,7 +4,7 @@
  * @licence GNU GPL v2+
  * @author Kai Nissen <kai.nissen@wikimedia.de>
  */
-( function ( Banner ) {
+( function ( Banner, $ ) {
 	'use strict';
 
 	var TP;
@@ -12,6 +12,7 @@
 	function Tracking() {
 		var self = this;
 		this._tracker = null;
+		this._eventsTracked = [];
 
 		$( document ).ready( function () {
 			self.initTrackingLib();
@@ -86,13 +87,17 @@
 	 * bind click events to elements as configured
 	 */
 	TP.initClickHandlers = function () {
+		var self = this;
 		$.each( Banner.config.tracking.events, function ( key, settings ) {
 			$( settings.clickElement ).click( function () {
-				Banner.tracking.trackVirtualPageView( key );
+				if ( $.inArray( key, self._eventsTracked ) === -1 ) {
+					Banner.tracking.trackVirtualPageView( key );
+					self._eventsTracked.push( key );
+				}
 			} );
 		} );
 	};
 
 	Banner.tracking = new Tracking();
 
-} )( Banner );
+} )( Banner, jQuery );

--- a/sensitive-banner-static/sensitive-banner-js-config.template.php
+++ b/sensitive-banner-static/sensitive-banner-js-config.template.php
@@ -42,6 +42,25 @@
 			form: {
 				formId: 'donationForm',
 				formAction: 'https://test.wikimedia.de/spenden/index.php?piwik_campaign={{{CampaignName}}}&piwik_kwd={{{BannerName}}}'
+			},
+			tracking: {
+				keyword: '{{{BannerName}}}',
+				libUrl: 'https://test.wikimedia.de/piwik.js',
+				trackerUrl: 'https://test.wikimedia.de/piwik.php',
+				siteId: 1,
+				baseUrl: 'https://spenden.wikimedia.de/',
+				events: {
+					BANNER_CLOSED: {
+						sample: 0.01,
+						clickElement: '#WMDE_Banner-close',
+						pathName: 'banner-closed'
+					},
+					BANNER_EXPANDED: {
+						sample: 0.01,
+						clickElement: '#WMDE_BannerForm-payment button',
+						pathName: 'banner-expanded'
+					}
+				}
 			}
 		}
 	);


### PR DESCRIPTION
When deploying on production, Piwik's URLs should be changed to those starting with "tracking.wikimedia.de".
The template intentionally uses non-existing test.wikimedia.de Piwik, as I'd rather not call the production Piwik when doing testing etc.

Tracking of the closing is currently quite redundant with this `banner.tracking` class, as it it already being done in https://github.com/wmde/FundraisingBanners/blob/master/sensitive-banner-static/res/common-banner.js#L6-L8
Piwik wouldn't count closing twice, though. But maybe it would make more sense to only use the "new" tracking class for tracking that the form has been expanded?

For testing use your own Piwik instance and change `sample`s to 1 (or more ;))