### PR TITLE
Replace logos

### DIFF
--- a/sensitive-banner-static/res/sensitive-banner.css
+++ b/sensitive-banner-static/res/sensitive-banner.css
@@ -273,6 +273,11 @@ button#WMDE_BannerFullForm-finish.waiting, button#WMDE_BannerFullForm-finish-sep
     float: left;
 }
 
+#WMDE_Banner #globalsign-siteseal {
+    width: 125px;
+    float: left;
+}
+
 #confirm_sepa {
     margin-bottom: 240px;
 }

--- a/sensitive-banner-static/sensitive-banner.inc.php
+++ b/sensitive-banner-static/sensitive-banner.inc.php
@@ -999,8 +999,8 @@ vorüber.</span> Über 14 Millionen Mal wird unser Spendenaufruf täglich angeze
 			<ul>
 				<li>
 					<div class="lightbox-list-item">
-						<img src="img/global-sign.png">
-						<img style="float: right;" src="img/owasp.png">
+						<!--- DO NOT EDIT - GlobalSign SSL Site Seal Code - DO NOT EDIT ---><table id="globalsign-siteseal" width="125" title="CLICK TO VERIFY: This site uses a GlobalSign SSL Certificate to secure your personal information." ><tr><td><span id="ss_img_wrapper_gmogs_image_90-35_en_dblue"><a href="https://www.globalsign.com/" target=_blank title="GlobalSign Site Seal" rel="nofollow"><img alt="SSL" border=0 id="ss_img" src="//seal.globalsign.com/SiteSeal/images/gs_noscript_90-35_en.gif"></a></span><script type="text/javascript" src="//seal.globalsign.com/SiteSeal/gmogs_image_90-35_en_dblue.js"></script></td></tr></table><!--- DO NOT EDIT - GlobalSign SSL Site Seal Code - DO NOT EDIT --->
+						<img style="float: right;" src="https://upload.wikimedia.org/wikipedia/commons/b/b5/OWASP_Logo.png" width="36" height="36">
 
 						<div style="clear: right; height: 7px;"></div>
 					</div>


### PR DESCRIPTION
Link OWASP logo to OWASP logo on commons.
Replace static SiteSeal graphic with JS, as recommended by
https://www.globalsign.com/de-de/ssl/secure-site-seal/

Now only the icons.svg is missing.