### PR TITLE
Add iframe field to sensitive banner's form and used in credit card donations

### DIFF
--- a/sensitive-banner-static/res/sensitive-banner.js
+++ b/sensitive-banner-static/res/sensitive-banner.js
@@ -149,6 +149,7 @@ function showFullForm() {
 function hideFullForm() {
 	$( '#zahlweise' ).val( '' );
 	$( '#form_action' ).prop( 'name', '' );
+	$( '#donationIframe' ).val( '' );
 	isOpen = false;
 	$( '#WMDE_BannerFullForm-details' ).slideUp( 400, function() {
 		$( '#WMDE_Banner' ).css( 'position', 'fixed' );
@@ -234,6 +235,7 @@ function showDebitDonation( button ) {
 	} else {
 		$( '#zahlweise' ).val( 'BEZ' );
 		$( '#form_action' ).prop( 'name', 'go_prepare--pay:einzug' );
+		$( '#donationIframe' ).val( '' );
 		$( '#WMDE_Banner-debit-type' ).slideDown();
 		$( '#WMDE_Banner-anonymous' ).slideUp();
 		$( '#WMDE_BannerFullForm-finish' ).hide();
@@ -255,6 +257,7 @@ function showDepositDonation( button ) {
 	} else {
 		$( '#zahlweise' ).val( 'UEB' );
 		$( '#form_action' ).prop( 'name', 'go_prepare--pay:ueberweisung' );
+		$( '#donationIframe' ).val( '' );
 		showNonDebitParts( button );
 	}
 }
@@ -265,6 +268,7 @@ function showCreditDonation( button ) {
 	} else {
 		$( '#zahlweise' ).val( 'MCP' );
 		$( '#form_action' ).prop( 'name', 'go_prepare--pay:micropayment-i' );
+		$( '#donationIframe' ).val( 'micropayment-iframe' );
 		showNonDebitParts( button );
 	}
 }
@@ -275,6 +279,7 @@ function showPayPalDonation( button ) {
 	} else {
 		$( '#zahlweise' ).val( 'PPL' );
 		$( '#form_action' ).prop( 'name', 'go_prepare--pay:paypal' );
+		$( '#donationIframe' ).val( '' );
 		showNonDebitParts( button );
 	}
 }

--- a/sensitive-banner-static/sensitive-banner.inc.php
+++ b/sensitive-banner-static/sensitive-banner.inc.php
@@ -619,6 +619,7 @@ vorüber.</span> Über 14 Millionen Mal wird unser Spendenaufruf täglich angeze
 			<input type="hidden" name="intervalType" id="intervalType" value="0"/>
 			<input type="hidden" id="form-page" name="form" value="{{{form-name}}}"/>
 			<input type="hidden" id="form_action" name="" value="Jetzt für Wikipedia spenden" />
+			<input type="hidden" id="donationIframe" name="iframe" value="" />
 			<input type="hidden" id="wikilogin" name="wikilogin" value="no"/>
 			<input type="hidden" id="impCount" name="impCount" value=""/>
 			<input type="hidden" id="bImpCount" name="bImpCount" value=""/>


### PR DESCRIPTION
As done in https://github.com/wmde/fundraising/blob/master/skin/10h16/_js/spenden.wikimedia.js#L476

Without this parameter, donation website displays empty page (with message about form not existing or so). After adding this credit card donation seem to work as on the donation site.