### PR TITLE
Add campaign and banner names as tracking parameters of the in-banne…

### DIFF
--- a/sensitive-banner-static/sensitive-banner-js-config.template.php
+++ b/sensitive-banner-static/sensitive-banner-js-config.template.php
@@ -41,7 +41,7 @@
 			},
 			form: {
 				formId: 'donationForm',
-				formAction: 'https://test.wikimedia.de/spenden/index.php'
+				formAction: 'https://test.wikimedia.de/spenden/index.php?piwik_campaign={{{CampaignName}}}&piwik_kwd={{{BannerName}}}'
 			}
 		}
 	);


### PR DESCRIPTION
…r donations

~~@WMDE-Fisch: does something still need to be done to have those awesome `{{{values}}}` passed on wikipedia.de? At least `{{{form-name}}}` has been already in the form but it does not seem to be resolved in wpde~~ - this question is already answered, changing those `{{{things}}}` is part of deployment of wpde.