### PR TITLE
unified error message for invalid bank data

### DIFF
--- a/js/banner/banner.form.js
+++ b/js/banner/banner.form.js
@@ -133,7 +133,7 @@
 			$( '#bank-name' ).val( data.bankName ? data.bankName : '' );
 		} else {
 			$iban.val( '' );
-			errorMessage = data.message || 'Die eingegebenen Bankdaten sind nicht korrekt.';
+			errorMessage = 'Die eingegebenen Bankdaten sind nicht korrekt.';
 			this._showError( $iban, errorMessage );
 			this._showError( $( '#account-number' ), errorMessage );
 		}


### PR DESCRIPTION
The original message "Die angegebenen Daten konnten nicht in eine IBAN konvertiert werden." is a bit to long in our case.