### PR TITLE
Handle "edit data" links on the SEPA mandate confirmation step

### DIFF
--- a/js/banner/banner.form.js
+++ b/js/banner/banner.form.js
@@ -17,6 +17,7 @@
 			self._initSubmitHandler();
 			self._initBankDataHandler();
 			self._initFieldClearHandlers();
+			self._initValidationResetHandler();
 		} );
 	}
 
@@ -83,6 +84,14 @@
 
 	Form.prototype._initBankDataHandler = function () {
 		$( '#account-number, #bank-code, #iban' ).on( 'change', this.checkBankData.bind( this ) );
+	};
+
+	Form.prototype._initValidationResetHandler = function () {
+		var self = this,
+			form = $( '#' + banner.config.form.formId );
+		form.on( 'banner:validationReset', function () {
+			self.validated = false;
+		} );
 	};
 
 	Form.prototype.checkBankData = function ( evt ) {

--- a/sensitive-banner-static/res/sensitive-banner.js
+++ b/sensitive-banner-static/res/sensitive-banner.js
@@ -44,6 +44,9 @@ $( function() {
 		unlockForm();
 	} );
 
+	$( '.WMDE_BannerFullForm-confirm-edit' ).on( 'click', function () {
+		debitBackToFirstStep();
+	} );
 
 	paymentButtons.hover( function() {
 			if ( !isOpen ) $( '#WMDE_BannerFullForm-arrow' ).show();
@@ -252,6 +255,17 @@ function getCurrentDateString() {
 		+ month
 		+ '.'
 		+ now.getFullYear();
+}
+
+function debitBackToFirstStep() {
+	$( '#donationForm' ).trigger( 'banner:validationReset' );
+	$( '#WMDE_BannerFullForm-step2' ).slideToggle( 400, function () {
+		$( '#WMDE_BannerFullForm-step1' ).slideToggle();
+	} );
+
+	$( 'html, body' ).animate( {
+		scrollTop: 0
+	}, 'slow' );
 }
 
 /* Payment methods show and hide */


### PR DESCRIPTION
If "validated" flag of the banner js object is not reset after going back to the first-step screen, clicking the submit button sends to the form data to the donation website. As normally "SEPA confirmation" related fields are not yet checked, this results in showing empty page and storing unconfirmed direct-debit donation data.

Feel free to suggest better way of handling this.

I am also wondering why the "edit data" links ("Betrag ändern" and "Daten oder Zahlungsart ändern") do not behave like links (ie. no cursor change while hovering). Is it intended?