### PR TITLE
Fix URL of validation API in sensitive banner's config template

### DIFF
--- a/sensitive-banner-static/sensitive-banner-js-config.template.php
+++ b/sensitive-banner-static/sensitive-banner-js-config.template.php
@@ -3,7 +3,7 @@
 	Banner.config.setConfig(
 		{
 			api: {
-				apiUrl: 'https://test.wikimedia.de/spenden/ajax.php'
+				apiUrl: 'https://test.wikimedia.de/ajax.php'
 			},
 			encryption: {
 				libUrl: '../js/lib/openpgp.min.js',


### PR DESCRIPTION
This just in the template, so it is not crucial. Might still be misleading, though.