### PR TITLE
Fix checking if recurring donation has been chosen in the in-banner form

### DIFF
--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -181,7 +181,7 @@ function validateForm() {
 			break;
 	}
 
-	if ( $( '#interval_multiple' ).attr( 'checked' ) === 'checked' ) {
+	if ( $( '#interval_multiple' ).is( ':checked' ) ) {
 		if ( $( 'input[name=interval]:checked', form ).length !== 1 ) {
 			alert( 'Es wurde kein Zahlungsintervall ausgewählt.' );
 			return false;


### PR DESCRIPTION
If am not mistaken this caused all banner (I mean the "normal" one and the "sensitive banner") to ignore donor selecting a recurring donation and the interval. After getting to the donation website, it is always showing "einmalig".

I've already fixed this on Central Notice. JS file should be deployed on wikipedia.de after it is merged.