### PR TITLE
Improve error messages

### DIFF
--- a/js/banner/banner.form.js
+++ b/js/banner/banner.form.js
@@ -12,6 +12,7 @@
 		this.validated = false;
 		this.validationPending = false;
 		this.bankCheckPending = false;
+		this.invalidElements = 0;
 		$( document ).ready( function () {
 			self.amountValidationAnchor = $( '#amount75' );
 			self._initSubmitHandler();
@@ -153,8 +154,12 @@
 		this.bankCheckPending = false;
 	};
 
+	/**
+	 * Remove positive and negative validation information from all form fields
+	 */
 	Form.prototype._clearValidity = function () {
 		var self = this;
+		this.invalidElements = 0;
 		$( '#' + banner.config.form.formId + ' :input:not([type=hidden])' ).each( function ( index, element ) {
 			self._clearElementValidity( $( element ) );
 		} );
@@ -252,10 +257,12 @@
 		$( '#' + banner.config.form.formId + ' :input:not([type=hidden])' ).each( function ( index, element ) {
 			if ( $.inArray( $( element ).attr( 'name' ), fieldsMissingValue ) > -1 ) {
 				self._markMissing( $( element ) );
+				self.invalidElements++;
 				return true;
 			}
 			if ( $.inArray( $( element ).attr( 'name' ), fieldsWithInvalidValue ) > -1 ) {
 				self._markInvalid( $( element ) );
+				self.invalidElements++;
 				return true;
 			}
 			self._markValid( $( element ) );
@@ -280,8 +287,11 @@
 		}
 		if ( errorText ) {
 			errorBox = this._showError( this.amountValidationAnchor, errorText );
-			this._addErrorRemovalHandler( $( '#' + banner.config.form.formId + ' .amount-radio' ), errorBox, 'click' );
-			this._addErrorRemovalHandler( $( '#amount-other-input' ), errorBox );
+			if ( errorBox ) {
+				this._addErrorRemovalHandler( $( '#' + banner.config.form.formId + ' .amount-radio' ), errorBox, 'click' );
+				this._addErrorRemovalHandler( $( '#amount-other-input' ), errorBox );
+			}
+			this.invalidElements++;
 		}
 	};
 
@@ -312,6 +322,10 @@
 		$element.addClass( 'invalid' );
 		$( '.validation', $parent ).addClass( 'icon-bug' );
 		if ( !$( '.form-field-error-box', $parent ).length ) {
+			// Only show one error box
+			if ( this.invalidElements ) {
+				return;
+			}
 			$errorBox = $(
 				'<div class="form-field-error-box"><div class="form-field-error-arrow"></div><span class="form-field-error-text">' +
 				errorText +

--- a/sensitive-banner-static/res/sensitive-banner.css
+++ b/sensitive-banner-static/res/sensitive-banner.css
@@ -210,6 +210,7 @@ button#WMDE_BannerFullForm-finish.waiting, button#WMDE_BannerFullForm-finish-sep
     color: #C25959;
     padding: 2px 2px 2px 18px;
     font-size: 13px;
+    white-space: nowrap;
 }
 
 #WMDE_BannerFullForm div.form-field-error-arrow {
@@ -221,12 +222,21 @@ button#WMDE_BannerFullForm-finish.waiting, button#WMDE_BannerFullForm-finish-sep
     margin: auto;
 }
 
+#WMDE_BannerFullForm-step1 div, #WMDE_BannerFullForm-step1 td {
+    position: relative;
+}
+
 #WMDE_BannerFullForm .validation {
     position: absolute;
     height: 11px;
     width: 11px;
-    margin-left: -15px;
-    margin-top: 3px;
+    right: 14px;
+    bottom: 3px;
+}
+
+#WMDE_BannerFullForm div > .validation {
+    right: 4px;
+    padding: inherit;
 }
 
 #WMDE_BannerFullForm .icon-bug {

--- a/sensitive-banner-static/res/sensitive-banner.js
+++ b/sensitive-banner-static/res/sensitive-banner.js
@@ -103,6 +103,7 @@ $( function () {
 
 	$( '#donationForm' ).on( 'banner:validationSucceeded', function ( evt ) {
 		unlockForm();
+		$( '#WMDE_BannerFullForm-finish' ).removeClass( 'waiting' );
 		if ( $( '#zahlweise' ).val() === 'BEZ' ) {
 			debitNextStep();
 			evt.preventDefault();


### PR DESCRIPTION
Display only one message.
Position the icons correctly.
Remove the spinner when really submitting the form data.
Don't linebreak error messages.

This is for https://github.com/wmde/fundraising/issues/785