### PR TITLE
Improve compatibility for wikipedia.de

### DIFF
--- a/js/banner/banner.form.js
+++ b/js/banner/banner.form.js
@@ -26,8 +26,9 @@
 		/* globals alert */
 		var self = this,
 			form = $( '#' + banner.config.form.formId ),
+			formAction = banner.config.form.formAction.replace( '&amp;', '&' ), // wikipedia.de mangles & chars
 			formData;
-		form.prop( 'action', banner.config.form.formAction );
+		form.prop( 'action', formAction );
 		form.on( 'submit', function () {
 			if ( !self.validated && !self.validationPending ) {
 				self.validated = false;

--- a/js/banner/banner.form.js
+++ b/js/banner/banner.form.js
@@ -23,6 +23,7 @@
 	}
 
 	Form.prototype._initSubmitHandler = function () {
+		/* globals alert */
 		var self = this,
 			form = $( '#' + banner.config.form.formId ),
 			formData;
@@ -34,8 +35,7 @@
 				self._clearValidity();
 				try {
 					formData = self._getFormData();
-				}
-				catch (err) {
+				} catch ( err ) {
 					if ( err.alertMessage ) {
 						alert( err.alertMessage );
 					}

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -337,6 +337,9 @@ function addBannerSpaceWithRollo() {
 			bannerDivElement.css( 'background', 'none' );
 			break;
 	}
+	bannerDivElement.css( 'display', 'block' );
+	bannerDivElement.animate( { top: 0 }, 1000 );
+	setTimeout( animateProgressBar, 1000 );
 }
 
 function removeBannerSpace() {

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -291,28 +291,51 @@ function getAmount() {
 
 function addBannerSpace() {
 	var expandableBannerHeight = $( 'div#WMDE_Banner' ).height() + 44,
-			bannerDivElement = $( '#WMDE_Banner' ),
-			skin = getSkin();
+		bannerDivElement = $( '#WMDE_Banner' ),
+		skin = getSkin();
 
-	if ( showBanner ) {
-		switch ( skin ) {
-			// switch ( skin ) { TODO fix when non-static
-			case 'vector':
-				bannerDivElement.css( 'top', 0 - expandableBannerHeight );
-				$( '#mw-panel' ).animate( { top: expandableBannerHeight + 160 }, 1000 );
-				$( '#mw-head' ).animate( { top: expandableBannerHeight }, 1000 );
-				$( '#mw-page-base' ).animate( { paddingTop: expandableBannerHeight }, 1000 );
-				break;
-			case 'monobook':
-				$( '#globalWrapper' ).css( 'position', 'relative' );
-				$( '#globalWrapper' ).css( 'top', expandableBannerHeight );
-				bannerDivElement.css( 'top', '-20px' );
-				bannerDivElement.css( 'background', 'none' );
-				break;
-		}
-		bannerDivElement.css( 'display', 'block' );
-		bannerDivElement.animate( { top: 0 }, 1000 );
-		setTimeout( animateProgressBar, 1000 );
+	if ( !showBanner ) {
+		return;
+	}
+	switch ( skin ) {
+		case 'vector':
+			bannerDivElement.css( 'top', 0 );
+			bannerDivElement.css( 'display', 'block' );
+			$( '#mw-panel' ).css( 'top' expandableBannerHeight + 160 );
+			$( '#mw-head' ).css( 'top', expandableBannerHeight );
+			$( '#mw-page-base' ).css ( 'paddingTop', expandableBannerHeight );
+			break;
+		case 'monobook':
+			$( '#globalWrapper' ).css( 'position', 'relative' );
+			$( '#globalWrapper' ).css( 'top', expandableBannerHeight );
+			bannerDivElement.css( 'top', '-20px' );
+			bannerDivElement.css( 'background', 'none' );
+			break;
+	}
+	setTimeout( animateProgressBar, 1000 );
+}
+
+function addBannerSpaceWithRollo() {
+	var expandableBannerHeight = $( 'div#WMDE_Banner' ).height() + 44,
+		bannerDivElement = $( '#WMDE_Banner' ),
+		skin = getSkin();
+
+	if ( !showBanner ) {
+		return;
+	}
+	switch ( skin ) {
+		case 'vector':
+			bannerDivElement.css( 'top', 0 - expandableBannerHeight );
+			$( '#mw-panel' ).animate( { top: expandableBannerHeight + 160 }, 1000 );
+			$( '#mw-head' ).animate( { top: expandableBannerHeight }, 1000 );
+			$( '#mw-page-base' ).animate( { paddingTop: expandableBannerHeight }, 1000 );
+			break;
+		case 'monobook':
+			$( '#globalWrapper' ).css( 'position', 'relative' );
+			$( '#globalWrapper' ).css( 'top', expandableBannerHeight );
+			bannerDivElement.css( 'top', '-20px' );
+			bannerDivElement.css( 'background', 'none' );
+			break;
 	}
 }
 

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -303,7 +303,7 @@ function addBannerSpace() {
 			bannerDivElement.css( 'display', 'block' );
 			$( '#mw-panel' ).css( 'top', expandableBannerHeight + 160 );
 			$( '#mw-head' ).css( 'top', expandableBannerHeight );
-			$( '#mw-page-base' ).css ( 'paddingTop', expandableBannerHeight );
+			$( '#mw-page-base' ).css( 'paddingTop', expandableBannerHeight );
 			break;
 		case 'monobook':
 			$( '#globalWrapper' ).css( 'position', 'relative' );

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -165,10 +165,6 @@ function getCurrentGermanDay() {
 	}
 }
 
-function centralNoticeExists() {
-	return typeof mw !== 'undefined' && typeof mw.centralNotice !== 'undefined';
-}
-
 function addPointsToNum( num ) {
 	// jscs:disable disallowImplicitTypeConversion
 	num = parseInt( num, 10 ) + '';

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -162,6 +162,10 @@ function getCurrentGermanDay() {
 	}
 }
 
+function centralNoticeExists() {
+	return typeof mw !== 'undefined' && typeof mw.centralNotice !== 'undefined';
+}
+
 function addPointsToNum( num ) {
 	// jscs:disable disallowImplicitTypeConversion
 	num = parseInt( num, 10 ) + '';

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -454,7 +454,7 @@ function getFillWidth( donationBarWidth, donationTarget, donationsCollected ) {
  * placeholders with values fram a global object
  */
 function replaceWikiVars( text ) {
-	var re = /\{\{\{([^\}]+)\}\}\}/,
+	var re = /\{\{\{([^\}]+)\}\}\}/g,
 		wikiVarMatch;
 	while ( ( wikiVarMatch = re.exec( text ) ) !== null ) {
 		if ( GlobalBannerSettings[ wikiVarMatch[ 1 ] ] ) {

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -301,7 +301,7 @@ function addBannerSpace() {
 		case 'vector':
 			bannerDivElement.css( 'top', 0 );
 			bannerDivElement.css( 'display', 'block' );
-			$( '#mw-panel' ).css( 'top' expandableBannerHeight + 160 );
+			$( '#mw-panel' ).css( 'top', expandableBannerHeight + 160 );
 			$( '#mw-head' ).css( 'top', expandableBannerHeight );
 			$( '#mw-page-base' ).css ( 'paddingTop', expandableBannerHeight );
 			break;

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -3,6 +3,9 @@
 /* globals mw, alert, GlobalBannerSettings */
 var finalDateTime = new Date( 2016, 0, 1, 5, 0, 0 ),
 	goalSum = 8600000,
+	/* jshint -W079 */
+	GlobalBannerSettings = typeof GlobalBannerSettings !== 'undefined' ? GlobalBannerSettings : {},
+	/* jshint +W079 */
 	baseDate = replaceWikiVars( '{{{donations-date-base}}}' ),
 	collectedBase = parseInt( replaceWikiVars( '{{{donations-collected-base}}}' ), 10 ),
 	donorsBase = parseInt( replaceWikiVars( '{{{donators-base}}}' ), 10 ),

--- a/sensitive-banner-static/res/sensitive-banner.css
+++ b/sensitive-banner-static/res/sensitive-banner.css
@@ -137,7 +137,7 @@ td#WMDE_BannerFullForm-wrapper {
 
 #WMDE_BannerFullForm .icon-question-sign {
     position: relative;
-    right: -227px;
+    right: -217px;
     margin-top: 7px;
     margin-left: 6px;
     background: transparent url('//upload.wikimedia.org/wikipedia/commons/a/ab/Grey_info_icon.png') no-repeat scroll center center;

--- a/sensitive-banner-static/res/sensitive-banner.js
+++ b/sensitive-banner-static/res/sensitive-banner.js
@@ -102,9 +102,14 @@ $( function () {
 	} );
 
 	$( '#donationForm' ).on( 'banner:validationSucceeded', function ( evt ) {
+		var zahlweiseVal = $( '#zahlweise' ).val(),
+			// Paypal page takes some time to load
+			spinnerTimout = zahlweiseVal === 'PPL' ? 2000 : 0 ;
 		unlockForm();
-		$( '#WMDE_BannerFullForm-finish' ).removeClass( 'waiting' );
-		if ( $( '#zahlweise' ).val() === 'BEZ' ) {
+		window.setTimeout( function () {
+			$( '#WMDE_BannerFullForm-finish' ).removeClass( 'waiting' );
+		}, spinnerTimout );
+		if ( zahlweiseVal === 'BEZ' ) {
 			debitNextStep();
 			evt.preventDefault();
 		} else {

--- a/sensitive-banner-static/res/sensitive-banner.js
+++ b/sensitive-banner-static/res/sensitive-banner.js
@@ -104,7 +104,7 @@ $( function () {
 	$( '#donationForm' ).on( 'banner:validationSucceeded', function ( evt ) {
 		var zahlweiseVal = $( '#zahlweise' ).val(),
 			// Paypal page takes some time to load
-			spinnerTimout = zahlweiseVal === 'PPL' ? 2000 : 0 ;
+			spinnerTimout = zahlweiseVal === 'PPL' ? 4000 : 0 ;
 		unlockForm();
 		window.setTimeout( function () {
 			$( '#WMDE_BannerFullForm-finish' ).removeClass( 'waiting' );

--- a/sensitive-banner-static/res/sensitive-banner.js
+++ b/sensitive-banner-static/res/sensitive-banner.js
@@ -21,7 +21,6 @@ $( function () {
 	} );
 	$( '#interval_multiple' ).on( 'click', function () {
 		$( '#WMDE_BannerForm-wrapper' ).css( 'height', '204px' );
-		$( '#interval1' ).prop( 'checked', 'checked' );
 	} );
 
 	paymentButtons.on( 'click', function ( e ) {

--- a/sensitive-banner-static/sensitive-banner.inc.php
+++ b/sensitive-banner-static/sensitive-banner.inc.php
@@ -145,7 +145,6 @@ vorüber.</span> Über 14 Millionen Mal wird unser Spendenaufruf täglich angeze
 													<td style="padding-left: 8px">
 														<input class="amount-radio" name="betrag_auswahl"
 															   onclick="document.donationForm.amountGiven.value = ''"
-															   checked="checked"
 															   id="amount5"
 															   value="5"
 															   type="radio">


### PR DESCRIPTION
Copied all the improvements from the DesktopBanner.js code:
- configurable cookie names
- New goal sum for 2015

Goal Sum is now configured at the top of the JS code. 

When this is merged, the fulltop banner on Wikipedia.de can use common-banner.js again and ditch DesktopBanner.js

Over time, this branch has also evolved into general fixes to make sensitive banner work on wikipedia.de
