### PR TITLE
Progressbar improvements

### DIFF
--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -322,6 +322,7 @@ function animateProgressBar() {
 			donationValueElement.html( dColl );
 		},
 		complete: function () {
+			$( '#donationText' ).show();
 			$( '#donationRemaining' ).show();
 			daysLeftElement.show();
 		}

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -278,7 +278,8 @@ function animateProgressBar() {
 		donationValueElement = $( '#donationValue' ),
 		remainingValueElement = $( 'valRem' ),
 		preFillValue = 0,
-		barWidth, dTarget, dCollected, dRemaining, fWidth, maxFillWidth, widthToFill;
+		barWidth, dTarget, dCollected, dRemaining, fWidth, maxFillWidth, widthToFill,
+		fillToBarRatio;
 
 	donationFillElement.clearQueue();
 	donationFillElement.stop();
@@ -294,6 +295,13 @@ function animateProgressBar() {
 	fWidth = dCollected / dTarget * barWidth;
 	maxFillWidth = barWidth - $( '#donationRemaining' ).width() - 16;
 	widthToFill = ( fWidth > maxFillWidth ) ? maxFillWidth : fWidth;
+	fillToBarRatio = widthToFill / barWidth;
+	if ( fillToBarRatio < 0.15 ) {
+		widthToFill = 0.15 * barWidth;
+		if ( widthToFill > 100 ) {
+			widthToFill = 100;
+		}
+	}
 
 	donationFillElement.animate( { width: widthToFill + 'px' }, {
 		duration: 3000,

--- a/sensitive-banner-static/res/progressbar.css
+++ b/sensitive-banner-static/res/progressbar.css
@@ -53,7 +53,6 @@
     font-size: 15px;
     color: white;
     font-weight: bold;
-    display: none;
 }
 
 #daysLeft {


### PR DESCRIPTION
Few things that has been required while preparing https://github.com/wmde/fundraising/issues/813:
 - text on the right of progress bar (remaining amount or donation goal) should not always be hidden. If it should be, and only shown after animation has finished, it should be hidden in the banner code, not in general progress bar's CSS file, I think
- text on the left side of the progress bar might also be hidden initially, and then shown after animation has finished. Change is showing it (if has been hidden)
 - I tried to tweak progress bar a bit, so it does not look too small even at the beginning of the campaign.