### PR TITLE
Correct lower limit on progress bar

### DIFF
--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -297,7 +297,7 @@ function animateProgressBar() {
 	// Fill at least 15%
 	widthToFill = Math.max( 0.15 * barWidth, widthToFill );
 	// Fill at least 100px (in case 15% fill is lower than 100px)
-	widthToFill = Math.max( 100, widthToFill );	
+	widthToFill = Math.max( 100, widthToFill );
 
 	donationFillElement.animate( { width: widthToFill + 'px' }, {
 		duration: 3000,

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -294,10 +294,8 @@ function animateProgressBar() {
 	fWidth = dCollected / dTarget * barWidth;
 	maxFillWidth = barWidth - $( '#donationRemaining' ).width() - 16;
 	widthToFill = Math.min( maxFillWidth, fWidth );
-	// Fill at least 15%
-	widthToFill = Math.max( 0.15 * barWidth, widthToFill );
-	// Fill at least 100px (in case 15% fill is lower than 100px)
-	widthToFill = Math.max( 100, widthToFill );
+	// Fill at least 100px or 15% (in case 15% fill is lower than 100px)
+	widthToFill = Math.max( 100, 0.15 * barWidth, widthToFill );
 
 	donationFillElement.animate( { width: widthToFill + 'px' }, {
 		duration: 3000,

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -2,7 +2,7 @@
 /*jshint unused: false */
 /* globals mw, alert, GlobalBannerSettings */
 var finalDateTime = new Date( 2016, 0, 1, 5, 0, 0 ),
-	goalSum = 8700000,
+	goalSum = 8600000,
 	baseDate = replaceWikiVars( '{{{donations-date-base}}}' ),
 	collectedBase = parseInt( replaceWikiVars( '{{{donations-collected-base}}}' ), 10 ),
 	donorsBase = parseInt( replaceWikiVars( '{{{donators-base}}}' ), 10 ),
@@ -288,19 +288,16 @@ function animateProgressBar() {
 	daysLeftElement.hide();
 
 	barWidth = $( '#donationMeter' ).width();
-	dTarget = parseInt( '8300000', 10 );
+	dTarget = goalSum;
 	dCollected = getApprDonationsRaw();
 	dRemaining = dTarget - dCollected;
 
 	fWidth = dCollected / dTarget * barWidth;
 	maxFillWidth = barWidth - $( '#donationRemaining' ).width() - 16;
-	widthToFill = ( fWidth > maxFillWidth ) ? maxFillWidth : fWidth;
+	widthToFill = Math.min( maxFillWidth, fWidth );
 	fillToBarRatio = widthToFill / barWidth;
 	if ( fillToBarRatio < 0.15 ) {
-		widthToFill = 0.15 * barWidth;
-		if ( widthToFill > 100 ) {
-			widthToFill = 100;
-		}
+		widthToFill = Math.max( 100, 0.15 * barWidth );
 	}
 
 	donationFillElement.animate( { width: widthToFill + 'px' }, {

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -278,8 +278,7 @@ function animateProgressBar() {
 		donationValueElement = $( '#donationValue' ),
 		remainingValueElement = $( '#valRem' ),
 		preFillValue = 0,
-		barWidth, dTarget, dCollected, dRemaining, fWidth, maxFillWidth, widthToFill,
-		fillToBarRatio;
+		barWidth, dTarget, dCollected, dRemaining, fWidth, maxFillWidth, widthToFill;
 
 	donationFillElement.clearQueue();
 	donationFillElement.stop();
@@ -295,10 +294,10 @@ function animateProgressBar() {
 	fWidth = dCollected / dTarget * barWidth;
 	maxFillWidth = barWidth - $( '#donationRemaining' ).width() - 16;
 	widthToFill = Math.min( maxFillWidth, fWidth );
-	fillToBarRatio = widthToFill / barWidth;
-	if ( fillToBarRatio < 0.15 ) {
-		widthToFill = Math.max( 100, 0.15 * barWidth );
-	}
+	// Fill at least 15%
+	widthToFill = Math.max( 0.15 * barWidth, widthToFill );
+	// Fill at least 100px (in case 15% fill is lower than 100px)
+	widthToFill = Math.max( 100, widthToFill );	
 
 	donationFillElement.animate( { width: widthToFill + 'px' }, {
 		duration: 3000,

--- a/sensitive-banner-static/sensitive-banner.inc.php
+++ b/sensitive-banner-static/sensitive-banner.inc.php
@@ -4,10 +4,10 @@
 <script type="text/javascript">
 // This script block only needs to be initialized on wp.de
 window.GlobalBannerSettings = {
-	'donations-date-base': '2015-11-10',
-	'donations-collected-base': '6025000',
-	'donators-base': '282100',
-	'appr-donations-per-minute': '104',
+	'donations-date-base': '2015-11-12',
+	'donations-collected-base': '640000',
+	'donators-base': '0',
+	'appr-donations-per-minute': '75',
 	'appr-donators-per-minute': '5.5',
 	'BannerName': 'wpde-151110-sensitive'
 };


### PR DESCRIPTION
Now the progress bar is at least 15% filled. If those 15% are less than
100 Pixel wide, the width is at least 100 Pixels to accomodate the text.

Use goalSum for dTarget instead of parsing a static string.

Changed banner settings to reflect data from currently running
campaigns.

This resolved the issues from https://github.com/wmde/fundraising/issues/833