### PR TITLE
Hidebanner cookie

### DIFF
--- a/js/lib/jquery.cookie.js
+++ b/js/lib/jquery.cookie.js
@@ -1,0 +1,114 @@
+/*!
+ * jQuery Cookie Plugin v1.4.1
+ * https://github.com/carhartl/jquery-cookie
+ *
+ * Copyright 2006, 2014 Klaus Hartl
+ * Released under the MIT license
+ */
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD (Register as an anonymous module)
+		define(['jquery'], factory);
+	} else if (typeof exports === 'object') {
+		// Node/CommonJS
+		module.exports = factory(require('jquery'));
+	} else {
+		// Browser globals
+		factory(jQuery);
+	}
+}(function ($) {
+
+	var pluses = /\+/g;
+
+	function encode(s) {
+		return config.raw ? s : encodeURIComponent(s);
+	}
+
+	function decode(s) {
+		return config.raw ? s : decodeURIComponent(s);
+	}
+
+	function stringifyCookieValue(value) {
+		return encode(config.json ? JSON.stringify(value) : String(value));
+	}
+
+	function parseCookieValue(s) {
+		if (s.indexOf('"') === 0) {
+			// This is a quoted cookie as according to RFC2068, unescape...
+			s = s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+		}
+
+		try {
+			// Replace server-side written pluses with spaces.
+			// If we can't decode the cookie, ignore it, it's unusable.
+			// If we can't parse the cookie, ignore it, it's unusable.
+			s = decodeURIComponent(s.replace(pluses, ' '));
+			return config.json ? JSON.parse(s) : s;
+		} catch(e) {}
+	}
+
+	function read(s, converter) {
+		var value = config.raw ? s : parseCookieValue(s);
+		return $.isFunction(converter) ? converter(value) : value;
+	}
+
+	var config = $.cookie = function (key, value, options) {
+
+		// Write
+
+		if (arguments.length > 1 && !$.isFunction(value)) {
+			options = $.extend({}, config.defaults, options);
+
+			if (typeof options.expires === 'number') {
+				var days = options.expires, t = options.expires = new Date();
+				t.setMilliseconds(t.getMilliseconds() + days * 864e+5);
+			}
+
+			return (document.cookie = [
+				encode(key), '=', stringifyCookieValue(value),
+				options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
+				options.path    ? '; path=' + options.path : '',
+				options.domain  ? '; domain=' + options.domain : '',
+				options.secure  ? '; secure' : ''
+			].join(''));
+		}
+
+		// Read
+
+		var result = key ? undefined : {},
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all. Also prevents odd result when
+			// calling $.cookie().
+			cookies = document.cookie ? document.cookie.split('; ') : [],
+			i = 0,
+			l = cookies.length;
+
+		for (; i < l; i++) {
+			var parts = cookies[i].split('='),
+				name = decode(parts.shift()),
+				cookie = parts.join('=');
+
+			if (key === name) {
+				// If second argument (value) is a function it's a converter...
+				result = read(cookie, value);
+				break;
+			}
+
+			// Prevent storing a cookie that we couldn't decode.
+			if (!key && (cookie = read(cookie)) !== undefined) {
+				result[name] = cookie;
+			}
+		}
+
+		return result;
+	};
+
+	config.defaults = {};
+
+	$.removeCookie = function (key, options) {
+		// Must not alter options, thus extending a fresh object...
+		$.cookie(key, '', $.extend({}, options, { expires: -1 }));
+		return !$.cookie(key);
+	};
+
+}));

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -11,7 +11,7 @@ var finalDateTime = new Date( 2016, 0, 1, 5, 0, 0 ),
 	;
 
 $( function () {
-	if ( mw && parseInt( $.cookie( 'centralnotice_wmde15_hide_cookie' ) ) === 1 ) {
+	if ( mw && parseInt( $.cookie( 'centralnotice_wmde15_hide_cookie' ), 10 ) === 1 ) {
 		mw.centralNotice.bannerData.hideResult = true;
 		mw.centralNotice.bannerData.hideReason = 'close';
 		return;

--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -11,12 +11,19 @@ var finalDateTime = new Date( 2016, 0, 1, 5, 0, 0 ),
 	;
 
 $( function () {
+	if ( mw && parseInt( $.cookie( 'centralnotice_wmde15_hide_cookie' ) ) === 1 ) {
+		mw.centralNotice.bannerData.hideResult = true;
+		mw.centralNotice.bannerData.hideReason = 'close';
+		return;
+	}
+
 	$( '#WMDE_Banner-close' ).click( function () {
 		if ( Math.random() < 0.01 ) {
 			$( '#WMDE_Banner-close-ct' ).attr( 'src', replaceWikiVars( 'https://spenden.wikimedia.de/piwik/piwik.php?idsite=1&url=https://spenden.wikimedia.de/banner-closed/{{{BannerName}}}&rec=1' ) );
 		}
-		mw.centralNotice.hideBanner();
+		$( '#WMDE_Banner' ).hide();
 		removeBannerSpace();
+		$.cookie( 'centralnotice_wmde15_hide_cookie', 1, { expires: new Date( '2015/12/31 23:59:59' ), path: '/' } );
 		return false;
 	} );
 


### PR DESCRIPTION
As requested in wmde/fundraising#837, this introduces a cookie that is set when users close a banner. The cookie will be valid until the campaign ends and prevents further banners from being displayed. Using `alterImpressionData` the banner loading will not count as an impression.

To force a banner to display the cookie value has to be ignored.

Note, that this PR depends on #77.