### PR TITLE
Fix tracking of "virtual page views" using Piwik

### DIFF
--- a/js/banner/banner.tracking.js
+++ b/js/banner/banner.tracking.js
@@ -37,13 +37,14 @@
 	 * @param {string} eventName
 	 */
 	TP.trackVirtualPageView = function ( eventName ) {
+		var virtualUrl;
 		if ( this.shouldTrack( eventName, this.getRandomNumber() ) ) {
-			this._tracker.trackPageView(
-				Banner.config.tracking.baseUrl +
+			virtualUrl = Banner.config.tracking.baseUrl +
 				Banner.config.tracking.events[ eventName ].pathName +
 				'/' +
-				Banner.config.tracking.keyword
-			);
+				Banner.config.tracking.keyword;
+			this._tracker.setCustomUrl( virtualUrl );
+			this._tracker.trackPageView( virtualUrl );
 		}
 	};
 


### PR DESCRIPTION
Current code is making call to Piwik API that is using the "virtual URL" as a title of "virtual page" to track, but the tracked URL is current page.
Due to this in-banner events have not been tracked as expected (see https://github.com/wmde/fundraising/issues/892).
This sets the URL of the page to track to the virtual URL.

See also refrence of the JS Piwik client: https://developer.piwik.org/api-reference/tracking-javascript