### PR TITLE
Add script allowing to define custom names for particular dates

### DIFF
--- a/js/customDayName.js
+++ b/js/customDayName.js
@@ -1,0 +1,34 @@
+/*jshint unused: false */
+
+var customDayNames = {
+	'06.12': 'Nikolaustag',
+	'13.12': '3. Advent',
+	'20.12': '4. Advent',
+	'24.12': 'Weihnachtstag',
+	'25.12': '1. Weihnachtstag',
+	'26.12': '2. Weihnachtstag'
+};
+
+function getDateString( date ) {
+	var dateString = '',
+		day = date.getDate(),
+		month = date.getMonth() + 1;
+	if ( day < 10 ) {
+		dateString += '0';
+	}
+	dateString += day;
+	dateString += '.';
+	if ( month < 10 ) {
+		dateString += month;
+	}
+	dateString += month;
+	return dateString;
+}
+
+function getCurrentDayName( fallbackFunction ) {
+	var	currentDateString = getDateString( new Date() );
+	if ( currentDateString in customDayNames ) {
+		return customDayNames[ currentDateString ];
+	}
+	return fallbackFunction();
+}


### PR DESCRIPTION
As requested in https://github.com/wmde/fundraising/issues/936.

Custom date-name pairs are hard-coded in the script but I didn't come up with the way to pass such things to script that would work for both CN and wpde banners.

`getCurrentDayName` function is intended to be rather flexible, though. Its parameter might by whatever string-returning function, so the script could be (at least in theory) used for both German and English banners.

Note that things like different phrase preceding the day name, as "an diesem" or "am heutigen" in https://github.com/wmde/fundraising/issues/936 require some extra magic that is in my opinion out of the scope of this script