### PR TITLE
add CSS to shrink fulltop on screens with low height

### DIFF
--- a/fulltop-banner/res/fulltop-banner.css
+++ b/fulltop-banner/res/fulltop-banner.css
@@ -450,3 +450,22 @@ body.rtl #WMDE_Banner-payment ul li {
 #WMDE_Banner-payment legend {
     display: block;
 }
+
+@media (max-height : 720px)  {
+    #WMDE_Banner-message {
+        font-size: .9em;
+        width: 60%}
+    #WMDE_Banner-message p { line-height: 1.2em; }
+    #WMDE_Banner-form { width: 40%; }
+    #WMDE_Banner-window button { font-size: .9em; }
+    #WMDE_Banner-frequency label  { font-size: .9em; }
+    #WMDE_Banner-amounts .predefined_amount  {
+        font-size: .9em;
+        height: initial;
+    }
+    #WMDE_Banner-footer { font-size: .8em; }
+    #WMDE_Banner-payment .WMDE_Banner-btn { min-height: 2em; }
+    .WMDE_Banner-btn { padding: .5em 0.1em; }
+    #amount_custom input { margin-top: 0.1em; }
+    #amount_custom .WMDE_Banner-btn { padding: 0 }
+}


### PR DESCRIPTION
see https://github.com/wmde/fundraising/issues/938

The changes differ from Peters changes. I found, that a wide broader approach is needed to let the fulltop still work good on our side. So instead of extending the rules controlling the bigger variants. I created a new rule-set for small screens in height.
