### PR TITLE
set enddate to 31.12.2015

### DIFF
--- a/sensitive-banner-static/res/common-banner.js
+++ b/sensitive-banner-static/res/common-banner.js
@@ -1,7 +1,7 @@
 /*jshint latedef: nofunc */
 /*jshint unused: false */
 /* globals mw, alert, GlobalBannerSettings */
-var finalDateTime = new Date( 2016, 0, 1, 5, 0, 0 ),
+var finalDateTime = new Date( 2015, 12, 31, 23, 59, 59 ),
 	goalSum = 8600000,
 	/* jshint -W079 */
 	GlobalBannerSettings = typeof GlobalBannerSettings !== 'undefined' ? GlobalBannerSettings : {},


### PR DESCRIPTION
Due to the fact, that the script for https://github.com/wmde/fundraising/issues/943 counts 1 day to much, this should be changed to the 31st.

If this should affect other methods negatively we could also hack the getDaysLeft() function. Opinions?
@KaiNissen @gbirke @wmde-manicki 