### PR TITLE
Fix position of full-top banner's footer

### DIFF
--- a/fulltop-banner/res/fulltop-banner.css
+++ b/fulltop-banner/res/fulltop-banner.css
@@ -372,7 +372,6 @@ body.rtl #WMDE_Banner-payment ul li {
 /* info footer */
 
 #WMDE_Banner-footer {
-    position: absolute;
     left: 0;
     top: 0;
     font-size: .8em;


### PR DESCRIPTION
"Real" banners have a typo in CSS files setting `poisition` of footer, which makes them display properly.
When adding lost fulltop's CSS file to the repository in https://github.com/wmde/FundraisingBanners/pull/92 I've noticed the typo and fixed it which made banner look really bad. Luckily, I haven't "fixed" that typo on Meta neither on wp.de.