### PR TITLE
Add a way to override the previously set "banner closed" cookie

### DIFF
--- a/js/common-banner.js
+++ b/js/common-banner.js
@@ -17,6 +17,7 @@ var finalDateTime = new Date( 2015, 11, 31, 23, 59, 59 ),
 	allBannersImpCookie = 'centralnotice_banner_impression_count',
 	singleBannerImpCookie = 'centralnotice_single_banner_impression_count',
 	bannerCloseTrackRatio = replaceWikiVars( '{{{banner-close-track-ratio}}}' ) || 0.01,
+	bannerClosedCookie = replaceWikiVars( '{{{banner-closed-cookie}}}' ),
 	bannerClosedCookieValue = replaceWikiVars( '{{{banner-closed-cookie-custom-value}}}' ) || '1',
 	showBanner = true,
 	messages = {
@@ -53,7 +54,7 @@ $( function () {
 		}
 		$( '#WMDE_Banner' ).hide();
 		removeBannerSpace();
-		setBannerClosedCookie( 'centralnotice_wmde15_hide_cookie' );
+		setBannerClosedCookie();
 
 		return false;
 	} );
@@ -80,12 +81,12 @@ $( function () {
 	} );
 } );
 
-function setBannerClosedCookie( cookieName ) {
+function setBannerClosedCookie() {
 	var currentDate = new Date(),
 		expiryDate;
 
 	expiryDate = new Date( currentDate.getFullYear() + 1, 0, 1 );
-	$.cookie( cookieName, bannerClosedCookieValue, { expires: expiryDate, path: '/' } );
+	$.cookie( bannerClosedCookie, bannerClosedCookieValue, { expires: expiryDate, path: '/' } );
 }
 
 function getDaysLeft() {
@@ -526,7 +527,7 @@ function onMediaWiki() {
 
 function bannerClosedCookieIsSet() {
 	if ( bannerClosedCookieValue !== '1' ) {
-		return $.cookie( 'centralnotice_wmde15_hide_cookie' ) === bannerClosedCookieValue;
+		return $.cookie( bannerClosedCookie ) === bannerClosedCookieValue;
 	}
-	return $.cookie( 'centralnotice_wmde15_hide_cookie' ) !== null && typeof $.cookie( 'centralnotice_wmde15_hide_cookie' ) !== 'undefined';
+	return $.cookie( bannerClosedCookie ) !== null && typeof $.cookie( bannerClosedCookie ) !== 'undefined';
 }

--- a/js/common-banner.js
+++ b/js/common-banner.js
@@ -17,6 +17,7 @@ var finalDateTime = new Date( 2015, 11, 31, 23, 59, 59 ),
 	allBannersImpCookie = 'centralnotice_banner_impression_count',
 	singleBannerImpCookie = 'centralnotice_single_banner_impression_count',
 	bannerCloseTrackRatio = replaceWikiVars( '{{{banner-close-track-ratio}}}' ) || 0.01,
+	bannerClosedCookieValue = replaceWikiVars( '{{{banner-closed-cookie-custom-value}}}' ) || '1',
 	showBanner = true,
 	messages = {
 		en: {
@@ -29,7 +30,7 @@ var finalDateTime = new Date( 2015, 11, 31, 23, 59, 59 ),
 		}
 	};
 
-if ( $.cookie( 'centralnotice_wmde15_hide_cookie' ) === '1' ) {
+if ( bannerClosedCookieIsSet() ) {
 	showBanner = false;
 }
 
@@ -84,7 +85,7 @@ function setBannerClosedCookie( cookieName ) {
 		expiryDate;
 
 	expiryDate = new Date( currentDate.getFullYear() + 1, 0, 1 );
-	$.cookie( cookieName, 1, { expires: expiryDate, path: '/' } );
+	$.cookie( cookieName, bannerClosedCookieValue, { expires: expiryDate, path: '/' } );
 }
 
 function getDaysLeft() {
@@ -521,4 +522,11 @@ function getSkin() {
 
 function onMediaWiki() {
 	return typeof mw === 'object' && typeof mw.centralNotice !== 'undefined';
+}
+
+function bannerClosedCookieIsSet() {
+	if ( bannerClosedCookieValue !== '1' ) {
+		return $.cookie( 'centralnotice_wmde15_hide_cookie' ) === bannerClosedCookieValue;
+	}
+	return $.cookie( 'centralnotice_wmde15_hide_cookie' ) !== null;
 }

--- a/js/common-banner.js
+++ b/js/common-banner.js
@@ -528,5 +528,5 @@ function bannerClosedCookieIsSet() {
 	if ( bannerClosedCookieValue !== '1' ) {
 		return $.cookie( 'centralnotice_wmde15_hide_cookie' ) === bannerClosedCookieValue;
 	}
-	return $.cookie( 'centralnotice_wmde15_hide_cookie' ) !== null;
+	return $.cookie( 'centralnotice_wmde15_hide_cookie' ) !== null && typeof $.cookie( 'centralnotice_wmde15_hide_cookie' ) !== 'undefined';
 }


### PR DESCRIPTION
As required for https://github.com/wmde/fundraising/issues/991

General idea described in https://github.com/wmde/fundraising/issues/991#issuecomment-165432381 and https://github.com/wmde/fundraising-infrastructure/wiki/How-to-activate-special-banner-features#ignoring-the-banner-closed-cookie

Please note that it is already live on Meta due to BA36 being urgent