### PR TITLE
fixed partly overlapped text next to pbar tip

### DIFF
--- a/css/progressbar.css
+++ b/css/progressbar.css
@@ -45,6 +45,7 @@
 
 #donationText {
     position: absolute;
+    right: 12px;
     height: 100%;
     width: 100%;
     text-align: right;


### PR DESCRIPTION
Went unnoticed for quite a while. If we don't want the € to be displayed, we should remove it from the element's content rather than having it overlapped by the tip.